### PR TITLE
Fix Verilog LRM violations for strict simulators (e.g. Synopsys VCS)

### DIFF
--- a/rtl/float/ComputeRecip.v
+++ b/rtl/float/ComputeRecip.v
@@ -147,9 +147,9 @@ module NewtonRaphsonIteration #(
     // x1 = x0 * x1
     // Clocks: 1
     ////////////////////////////////////////////////////////////////////////////
-    reg [MS + MS - 1 : 0] step2_x1; // Q3.x
     always @(posedge clk)
     if (ce) begin : step2
+        reg [MS + MS - 1 : 0] step2_x1; // Q3.x
         step2_x1 = step1_x0 * step1_x1;
         x1 <= { 1'b0, step2_x1[0 +: (MS - 1) + MS - 1] }; // Convert Q3.x to S1.x
     end

--- a/rtl/float/FloatAdd.v
+++ b/rtl/float/FloatAdd.v
@@ -46,6 +46,10 @@ module FloatAdd
     localparam EXPONENT_INVALID_VALUE = (2 ** MANTISSA_ONE_POS_SIZE) - 1;
 
 
+    // Declared here (before first use below) so the tool does not implicitly
+    // infer a 1-bit wire from the FindExponent port connection.
+    reg  [MANTISSA_CALC_SIZE - 1 : 0] two_mantissaSum;
+
     wire [MANTISSA_ONE_POS_SIZE - 1 : 0] exponentCorrection;
     FindExponent #(.EXPONENT_SIZE(MANTISSA_ONE_POS_SIZE), .VALUE_SIZE(MANTISSA_CALC_SIZE)) findExponent (two_mantissaSum, exponentCorrection);
 
@@ -64,6 +68,16 @@ module FloatAdd
         reg  [FLOAT_SIZE - 1 : 0] smallNumber;
         reg                       expSmallGreaterThanZero;
         reg                       expBigGreaterThanZero;
+        // Combinational temporaries. These feed the pipeline registers below; using
+        // blocking assignments on locals keeps the read-after-write semantics this
+        // computation relies on, while the module-scoped registers are driven only
+        // by non-blocking assignments (so they cannot race with the consuming stage).
+        reg  [EXPONENT_SIZE - 1 : 0]      bigNumberExponent;
+        reg  [EXPONENT_SIZE - 1 : 0]      smallNumberExponent;
+        reg  [MANTISSA_CALC_SIZE - 1 : 0] bigNumberMantissa;
+        reg  [EXPONENT_SIZE - 1 : 0]      exponentDiff;
+        reg  [MANTISSA_CALC_SIZE - 1 : 0] smallNumberMantissa;
+        reg  [MANTISSA_CALC_SIZE - 1 : 0] smallNumberMantissaDenormalized;
 
         // The addition requires that we have the same exponent for the big and small number.
         // Usually the small number will be adapted to the big number.
@@ -72,41 +86,46 @@ module FloatAdd
             bigNumber = bIn;
             smallNumber = aIn;
         end
-        else 
+        else
         begin
             bigNumber = aIn;
             smallNumber = bIn;
         end
-        one_bigNumberExponent = bigNumber[EXPONENT_POS +: EXPONENT_SIZE];
-        one_smallNumberExponent = smallNumber[EXPONENT_POS +: EXPONENT_SIZE];
+        bigNumberExponent = bigNumber[EXPONENT_POS +: EXPONENT_SIZE];
+        smallNumberExponent = smallNumber[EXPONENT_POS +: EXPONENT_SIZE];
 
-        expSmallGreaterThanZero = one_smallNumberExponent > 0;
-        expBigGreaterThanZero = one_bigNumberExponent > 0;
+        expSmallGreaterThanZero = smallNumberExponent > 0;
+        expBigGreaterThanZero = bigNumberExponent > 0;
 
-        one_bigNumberMantissa = {2'b0, expBigGreaterThanZero, bigNumber[MANTISSA_POS +: MANTISSA_SIZE]};
+        bigNumberMantissa = {2'b0, expBigGreaterThanZero, bigNumber[MANTISSA_POS +: MANTISSA_SIZE]};
 
         // Denormalize the small mantissa to enable the summerization with the big exponent
-        one_exponentDiff = one_bigNumberExponent - one_smallNumberExponent;
+        exponentDiff = bigNumberExponent - smallNumberExponent;
         // The timing here is really stressed. A fifth pipeline step could reduce stress here ...
-        if (one_exponentDiff >= MANTISSA_SIZE[0 +: EXPONENT_SIZE])
+        if (exponentDiff >= MANTISSA_SIZE[0 +: EXPONENT_SIZE])
         begin
             // If the small number is too small, set everything to zero
-            one_smallNumberMantissa = 0;
-            one_smallNumberMantissaDenormalized = 0;
+            smallNumberMantissa = 0;
+            smallNumberMantissaDenormalized = 0;
         end
-        else 
+        else
         begin
             // If the small number is big enough for summerization, denormalize it!
-            one_smallNumberMantissa = {2'b0, expSmallGreaterThanZero, smallNumber[MANTISSA_POS +: MANTISSA_SIZE]};
-            one_smallNumberMantissaDenormalized = one_smallNumberMantissa >>> one_exponentDiff[0 +: MANTISSA_WIDTH_LOG2];
+            smallNumberMantissa = {2'b0, expSmallGreaterThanZero, smallNumber[MANTISSA_POS +: MANTISSA_SIZE]};
+            smallNumberMantissaDenormalized = smallNumberMantissa >>> exponentDiff[0 +: MANTISSA_WIDTH_LOG2];
         end
 
-        one_exponentDiffGreaterZero = one_exponentDiff > 0;
+        one_bigNumberExponent <= bigNumberExponent;
+        one_smallNumberExponent <= smallNumberExponent;
+        one_bigNumberMantissa <= bigNumberMantissa;
+        one_exponentDiff <= exponentDiff;
+        one_smallNumberMantissa <= smallNumberMantissa;
+        one_smallNumberMantissaDenormalized <= smallNumberMantissaDenormalized;
+        one_exponentDiffGreaterZero <= exponentDiff > 0;
         one_bigNumberSign <= bigNumber[SIGN_POS];
         one_smallNumberSign <= smallNumber[SIGN_POS];
     end
 
-    reg  [MANTISSA_CALC_SIZE - 1 : 0] two_mantissaSum;
     reg                               two_mantissaSumSign;
     reg  [EXPONENT_SIZE - 1 : 0]      two_bigNumberExponent;
     reg  [EXPONENT_SIZE - 1 : 0]      two_smallNumberExponent;
@@ -116,6 +135,7 @@ module FloatAdd
         reg  [MANTISSA_CALC_SIZE - 1 : 0] bigNumberMantissaSigned;
         reg  [MANTISSA_CALC_SIZE - 1 : 0] smallNumberMantissaSigned;
         reg  [MANTISSA_CALC_SIZE - 1 : 0] sumMantissa;
+        reg                               sumMantissaSign;
 
         // We should round when we shift the mantissa (which is done in the previous step)
         // But we can also omit that and save logic and latency (when the rounding error can be accepted)
@@ -152,10 +172,10 @@ module FloatAdd
         sumMantissa = $signed(bigNumberMantissaSigned) + $signed(smallNumberMantissaSigned);
 
         // Safe the sign of the sum
-        two_mantissaSumSign = sumMantissa[MANTISSA_CALC_SIGN_POS];
+        sumMantissaSign = sumMantissa[MANTISSA_CALC_SIGN_POS];
 
         // Convert signed sum back to a unsigned number
-        if (two_mantissaSumSign)
+        if (sumMantissaSign)
         begin
             two_mantissaSum <= ~sumMantissa + 1;
         end
@@ -163,6 +183,7 @@ module FloatAdd
         begin
             two_mantissaSum <= sumMantissa;
         end
+        two_mantissaSumSign <= sumMantissaSign;
         two_bigNumberExponent <= one_bigNumberExponent;
         two_smallNumberExponent <= one_smallNumberExponent;
     end

--- a/rtl/float/IntToFloat.v
+++ b/rtl/float/IntToFloat.v
@@ -47,10 +47,13 @@ module IntToFloat
     localparam [EXPONENT_SIZE - 1 : 0] EXPONENT_BIAS = ((2 ** (EXPONENT_SIZE - 1)) - 1);
     localparam UNSIGNED_WORK_INT_SIZE_LOG2 = $clog2(UNSIGNED_WORK_INT_SIZE);
 
+    // Declared here (before first use below) so the tool does not implicitly
+    // infer a 1-bit wire from the FindExponent port connection.
+    reg  [UNSIGNED_WORK_INT_SIZE - 1 : 0]    one_number;
+
     wire [UNSIGNED_WORK_INT_SIZE_LOG2 - 1 : 0] exponent;
     FindExponent #(.EXPONENT_SIZE(UNSIGNED_WORK_INT_SIZE_LOG2), .VALUE_SIZE(UNSIGNED_WORK_INT_SIZE)) findExponent (one_number, exponent);
 
-    reg  [UNSIGNED_WORK_INT_SIZE - 1 : 0]    one_number;
     reg                                 one_sign;
     always @(posedge clk)
     if (ce) begin : Prepare
@@ -88,16 +91,21 @@ module IntToFloat
     always @(posedge clk)
     if (ce) begin : PreparePack
         reg [EXPONENT_SIZE - 1 : 0] exp;
+        // Combinational temporaries feeding the pipeline registers below. Driving
+        // the module-scoped registers with non-blocking assignments only keeps them
+        // from racing with the consuming Pack stage.
+        reg                         mantissaOverflow;
+        reg                         shiftLeft;
 
-        three_mantissaOverflow = two_number[two_exponent - MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2] - 1];
-        three_shiftLeft = two_exponent < MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2];
+        mantissaOverflow = two_number[two_exponent - MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2] - 1];
+        shiftLeft = two_exponent < MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2];
         exp = {{(EXPONENT_SIZE - UNSIGNED_WORK_INT_SIZE_LOG2){1'h0}}, two_exponent} + (EXPONENT_BIAS + offset);
         if (two_number == 0)
         begin
             three_number <= 0;
             three_exponent <= 0;
         end
-        else if (three_shiftLeft)
+        else if (shiftLeft)
         begin
             three_shiftSize <= MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2] - two_exponent;
             three_number <= two_number;
@@ -105,11 +113,13 @@ module IntToFloat
         end
         else
         begin
-            three_shiftSize <= ((two_exponent + {{(UNSIGNED_WORK_INT_SIZE_LOG2 - 1){1'b0}}, three_mantissaOverflow}) - MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2]);
+            three_shiftSize <= ((two_exponent + {{(UNSIGNED_WORK_INT_SIZE_LOG2 - 1){1'b0}}, mantissaOverflow}) - MANTISSA_SIZE[0 +: UNSIGNED_WORK_INT_SIZE_LOG2]);
             three_number <= two_number;
-            three_exponent <= exp + {{(EXPONENT_SIZE - 1){1'b0}}, three_mantissaOverflow};
+            three_exponent <= exp + {{(EXPONENT_SIZE - 1){1'b0}}, mantissaOverflow};
         end
 
+        three_mantissaOverflow <= mantissaOverflow;
+        three_shiftLeft <= shiftLeft;
         three_sign <= two_sign;
     end
 


### PR DESCRIPTION
These modules compile under Verilator but are rejected by strict LRM-conforming tools such as Synopsys VCS. Two distinct issues are fixed, with no change to simulated behavior (the Verilator unit tests in Unittest/ still pass):

1. Implicit net inferred from a port connection used before declaration. In FloatAdd and IntToFloat a reg (two_mantissaSum / one_number) was used as a FindExponent port connection above its declaration. Per the implicit-net rule this infers a 1-bit wire, the later reg declaration is then ignored, and the procedural assignment to it becomes illegal (VCS IBLHS-NT). Declare the reg before first use.

2. Module-scoped pipeline registers driven by blocking assignments and read from a different always block. This is a non-blocking hazard: the result depends on always-block scheduling order, risking a sim/synth mismatch. Confine blocking assignments to block-local temporaries and drive the module-scoped pipeline registers (one_* in FloatAdd, three_* in IntToFloat) with non-blocking assignments only. Also moved a module-scoped scratch reg (step2_x1) into its block in ComputeRecip.

FloatMul and FloatToInt already followed this pattern and were used as the reference.